### PR TITLE
use protected vars instead of private

### DIFF
--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -18,9 +18,9 @@ use Monolog\Logger;
 class TelegramHandler extends AbstractProcessingHandler
 {
 
-    private $token;
-    private $channel;
-    private $dateFormat;
+    protected $token;
+    protected $channel;
+    protected $dateFormat;
     const host = 'https://api.telegram.org/bot';
 
     /**


### PR DESCRIPTION
I suggest to use `protected` whenever possible instead of `private`, so that it's easier for other developers to inherit this class.