### PR TITLE
[fix] add missing ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require": {
         "monolog/monolog": "~1",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     }
 
 }


### PR DESCRIPTION
Use of `json_decode` function requires the `ext-json` extension to be specified.