### PR TITLE
[fix] add missing  definition

### DIFF
--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -21,6 +21,7 @@ class TelegramHandler extends AbstractProcessingHandler
     private $token;
     private $channel;
     private $dateFormat;
+    protected $timeOut;
     const host = 'https://api.telegram.org/bot';
 
     /**


### PR DESCRIPTION
The `$timeOut` was not defined in the vars list of the class.