### PR TITLE
Fix Incompatibility with new Monolog versions

### DIFF
--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -60,7 +60,7 @@ class TelegramHandler extends AbstractProcessingHandler
      * @param $record[] log data
      * @return void
      */
-    public function write(array $record)
+    public function write(array $record): void
     {
         $format = new LineFormatter;
         $context = $record['context'] ? $format->stringify($record['context']) : '';


### PR DESCRIPTION
Current version returns:
```TelegramHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void```
Due to the lack of `: void` 